### PR TITLE
add fiels in sign up form and edit form for user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  # before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    # For additional fields in app/views/devise/registrations/new.html.erb
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :description])
+
+    # For additional in app/views/devise/registrations/edit.html.erb
+    devise_parameter_sanitizer.permit(:account_update, keys: [:description])
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  # skip_before_action :authenticate_user!, only: :home
+
   def home
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -21,6 +21,9 @@
                 hint: "we need your current password to confirm your changes",
                 required: true,
                 input_html: { autocomplete: "current-password" } %>
+    <%= f.input :description,
+              required: true,
+              input_html: { autocomplete: "Write a little description about yourself" } %>
   </div>
 
   <div class="form-actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,6 +15,12 @@
     <%= f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
+      <%= f.input :username,
+            required: true,
+            input_html: { autocomplete: "Choose a username" } %>
+    <%= f.input :description,
+            required: true,
+            input_html: { autocomplete: "Write a little description about yourself" } %>
   </div>
 
   <div class="form-actions">


### PR DESCRIPTION
Adding missing fields : 

>> description and username in sign up form  >>>> modifying strong params in ApplicationsController (devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :description])
>> description in edit form for User >>>> modifying strong params in ApplicationsController (devise_parameter_sanitizer.permit(:account_update, keys: [:description])


Commented : 
# app/controllers/application_controller.rb
class ApplicationController < ActionController::Base
  #before_action :authenticate_user!
end

# app/controllers/pages_controller.rb
class PagesController < ApplicationController
  #skip_before_action :authenticate_user!, only: :home

  def home
  end
end