### PR TITLE
footer en bas non fixe et div en trop supprimé dans le render

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -8,7 +8,6 @@
   height: 60px;
   width: 100%;
   color: $ourwhite;
-  position: fixed;
   bottom: 0;
   text-align: center;
   left: 0;

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div>
+
   <div class="footer justify-content-center" >
     <div class="footer-links">
       © 2022 Guitarpick, Inc.
@@ -8,4 +8,3 @@
       <a href="#" target="_blank"><i class="textourwhite fab fa-twitter"></i></a>
       <a href="#" target="_blank"><i class="textourwhite fab fa-linkedin"></i></a>
   </div>
-</div>


### PR DESCRIPTION
Le render du footer avant une div en haut de HTML et en bas en trop du coup il rentré dans la largeur de la div du dashboard, d'où le bord sur la gauche et la droite

la position: fixed; a été supprimé, bottom: 0px suffit